### PR TITLE
fix config file path

### DIFF
--- a/main/server/index.js
+++ b/main/server/index.js
@@ -6,7 +6,7 @@ settings = {}; // global settings
 instance = null;
 
 module.exports = (USE_PORT) => {
-  const config = require("./config/config.json");
+  const config = require("./config/config.sample.json");
   const express = require("express");
   const app = express();
   const http = require("http");


### PR DESCRIPTION
The following error is being shown while trying to build for windows.

![pull-request](https://user-images.githubusercontent.com/35771432/125983556-5f681a29-f05a-47e5-a5d0-e2448e74493e.png)

I suppose this is because of giving config.json as filename [here](https://github.com/27px/Remote-File-Manager/blob/main/main/server/index.js#L9), instead of config.sample.json (which is the name of the actual file in the config folder)
